### PR TITLE
Fix missing images in production in AEGIS tools page

### DIFF
--- a/aegis-web/yo/Gruntfile.js
+++ b/aegis-web/yo/Gruntfile.js
@@ -276,6 +276,7 @@ module.exports = function (grunt) {
     usemin: {
       html: ['<%= yeoman.dist %>/{,*/}*.html'],
       css: ['<%= yeoman.dist %>/styles/{,*/}*.css'],
+      js: ['<%= yeoman.dist %>/scripts/{,*/}*.js'],
       options: {
         assetsDirs: [
           '<%= yeoman.dist %>',


### PR DESCRIPTION
Build process renames all assets with hash name and all references are updated.
JS files were not included in this process

fixes https://github.com/aegisbigdata/documentation/issues/129