### PR TITLE
Remove empty space from the top of Jobs page

### DIFF
--- a/aegis-web/yo/app/styles/aegis.css
+++ b/aegis-web/yo/app/styles/aegis.css
@@ -88,8 +88,8 @@
 
 /* Layout for jobs.html */
 
-.job-layout {
-  margin-top: 80px;
+.rg-row-top.job-content--row{
+   background: transparent !important;
 }
 
 div.job-content--page {

--- a/aegis-web/yo/app/styles/aegis.css
+++ b/aegis-web/yo/app/styles/aegis.css
@@ -96,6 +96,7 @@ div.job-content--page {
   height:100%; 
   overflow: hidden; 
   padding: 0 !important;
+  background: initial;
 }
 
 .job-content--row {


### PR DESCRIPTION
Remove empty space from the top of Jobs page ( closes @aegisbigdata/documentation/#196)
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
