### PR TITLE
Small fixes

### DIFF
--- a/aegis-web/yo/Gruntfile.js
+++ b/aegis-web/yo/Gruntfile.js
@@ -362,20 +362,27 @@ module.exports = function (grunt) {
             cwd: '<%= yeoman.app %>/images',
             src: '{,*/}*.{png,jpg,jpeg,gif}',
             dest: '<%= yeoman.dist %>/images'
-          }, {// <-- this will copy some unnecessary images to the styles folder 
-            // but is needed to copy images used by vendros .css. 
+          }, {// <-- this will copy some unnecessary images to the styles folder
+            // but is needed to copy images used by vendor.css
             expand: true,
             flatten: true,
             cwd: '<%= yeoman.bower %>',
             src: '*/*.{png,jpg,jpeg,gif}',
             dest: '<%= yeoman.dist %>/styles'
-          }, {// <-- this will copy some unnecessary images to the styles folder 
-            // but is needed to copy images used by vendros .css. 
+          }, {// <-- this will copy some unnecessary images to the styles folder
+            // but is needed to copy images used by vendor.css
             expand: true,
             flatten: true,
             cwd: '<%= yeoman.bower %>',
             src: '**/img/*.{png,jpg,jpeg,gif}',
             dest: '<%= yeoman.dist %>/img'
+          }, {// <-- this will copy leaflet images to the styles folder
+            // needed to find images used by vendor.css
+            expand: true,
+            flatten: true,
+            cwd: '<%= yeoman.bower %>',
+            src: '**/*.{png,jpg,jpeg,gif,svg}',
+            dest: '<%= yeoman.dist %>/styles/images'
           }
         ]
       }

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataCtrl.js
@@ -317,7 +317,6 @@ angular.module('hopsWorksApp')
             self.loadExtendedProjectMetadata = function () {
               ExtendedMetadataAPIService.getProjectMetadata(PROJECT_ID)
                 .then(function(data) {
-                  console.log(data.data);
                   self.updateModelsFromData(data.data);
                 })
                 .catch(function(error) {

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataCtrl.js
@@ -350,8 +350,8 @@ angular.module('hopsWorksApp')
                 }
               }
 
-              if ($scope.data.fields.license.model) graph.license = 'http://publications.europa.eu/resource/authority/licence/' + $scope.data.fields.license.model;
-              if ($scope.data.fields.language.model) graph.language = 'http://publications.europa.eu/resource/authority/language/' + $scope.data.fields.language.model;
+              if ($scope.data.fields.license.model  != '') graph.license = 'http://publications.europa.eu/resource/authority/licence/' + $scope.data.fields.license.model;
+              if ($scope.data.fields.language.model  != '') graph.language = 'http://publications.europa.eu/resource/authority/language/' + $scope.data.fields.language.model;
               graph.publisher['@type'] = 'http://xmlns.com/foaf/0.1/' + $scope.data.fields.publishertype.model;
 
               function generateSpatialData (latlngs, coordsNeedMapping) {

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
@@ -450,7 +450,7 @@ angular.module('hopsWorksApp')
               graph[0]['title'] = $scope.data.fields.title.model;
               graph[0]['description'] = $scope.data.fields.description.model;
 
-              if (fields.language.model) graph[0]['language'] = 'http://publications.europa.eu/resource/authority/language/' + fields.language.model;
+              if (fields.language.model != '') graph[0]['language'] = 'http://publications.europa.eu/resource/authority/language/' + fields.language.model;
               if (fields.keywords.tags.length) graph[0]['http://www.w3.org/ns/dcat#keyword'] = fields.keywords.model.split(',');
               if (fields.price.model) graph[0]['http://www.aegis-bigdata.eu/md/voc/core/price'] = fields.price.model;
               if (fields.sellable.model) graph[0]['http://www.aegis-bigdata.eu/md/voc/core/sellable'] = fields.sellable.model;

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
@@ -390,8 +390,8 @@ angular.module('hopsWorksApp')
               // Set temporal data fields
               if (index_temporal) {
                 let temporalData = graph[index_temporal];
-                if (temporalData.hasOwnProperty('http://schema.org/startDate')) fields.temporalfrom.model = moment(temporalData['http://schema.org/startDate']);
-                if (temporalData.hasOwnProperty('http://schema.org/endDate')) fields.temporalto.model = moment(temporalData['http://schema.org/endDate']);
+                if (temporalData.hasOwnProperty('http://schema.org/startDate')) fields.temporalfrom.model = moment(temporalData['http://schema.org/startDate']['@value']);
+                if (temporalData.hasOwnProperty('http://schema.org/endDate')) fields.temporalto.model = moment(temporalData['http://schema.org/endDate']['@value']);
               }
 
               if (index_contactpoint) {

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
@@ -423,7 +423,6 @@ angular.module('hopsWorksApp')
             self.loadDatasetMetadata = function () {
               ExtendedMetadataAPIService.getDatasetMetadata(self.DATASET_ID, self.PROJECT_ID)
                 .then(function(data) {
-                  console.log(data.data);
                   self.updateModelsFromData(data.data);
                 })
                 .catch(function(error) {

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
@@ -51,8 +51,10 @@ angular.module('hopsWorksApp')
                   MetadataHelperService, ProjectService, ExtendedMetadataService, ExtendedMetadataAPIService) {
             const PROJECT_ID = $routeParams.projectID;
             const DATASET_ID = $routeParams.dataSetID;
+            const parameters = $location.search();
             var self = this;
 
+            self.datasetName = decodeURI(parameters.datasetName);
             self.selectedField = null;
             self.metaData = {};
             self.metaDataDetail = {};
@@ -546,10 +548,10 @@ angular.module('hopsWorksApp')
               // Send to API
               ExtendedMetadataAPIService.createOrUpdateDatasetMetadata(DATASET_ID, PROJECT_ID, metadataObject)
                 .then(function(success) {
-                  growl.success('Project metadata successfully saved.', {title: 'Success', ttl: 5000});
+                  growl.success('Dataset metadata successfully saved.', {title: 'Success', ttl: 5000});
                 })
                 .catch(function(error) {
-                  growl.error('Server error: ' + error.status, {title: 'Error while saving project metadata', ttl: 5000, referenceId: 0});
+                  growl.error('Server error: ' + error.status, {title: 'Error while saving dataset metadata', ttl: 5000, referenceId: 0});
                 })
                 .finally(function() {
                   $scope.saveButtonIsDisabled = false;

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataDatasetCtrl.js
@@ -505,19 +505,22 @@ angular.module('hopsWorksApp')
               }
 
               // Add temporal object (from / to date)            
-              if (fields.temporalfrom.model || fields.temporalto.model) {
+              if (fields.temporalfrom.model) {
                 var temporalData = {
                   '@id': '_:b' + i,
                   '@type': 'dct:PeriodOfTime',
                   'schema:startDate': {
                     '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
-                    '@value': moment(fields.temporalfrom.model).format() || ''
-                  },
-                  'schema:endDate': {
-                    '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
-                    '@value': moment(fields.temporalto.model).format() || ''
+                    '@value': moment(fields.temporalfrom.model).format()
                   }
                 };
+
+                if (fields.temporalto.model) {
+                  temporalData['schema:endDate'] = {
+                    '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+                    '@value': moment(fields.temporalto.model).format()
+                  }
+                }
 
                 graph[0]['dct:temporal'] = {'@id': '_:b' + i};
                 graph.push(temporalData);

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
@@ -346,11 +346,18 @@ angular.module('hopsWorksApp')
                 
                   dataSetService.filePreview(path, "head").then(
                     function (success) {
+                      var truncation_length = 750;
                       var fileDetails = JSON.parse(success.data.data);
                       var content = fileDetails.filePreviewDTO[0].content;
                       var conv = new showdown.Converter({parseImgDimensions: true});
                       self.filePreviewLoaded = true;
                       $scope.filePreviewContents = conv.makeHtml(content);
+
+                      if ($scope.filePreviewContents.length > truncation_length) {
+                        $scope.filePreviewContents = $scope.filePreviewContents.substring(0, truncation_length) + '\n\n[...]';
+                      }
+
+                      console.log($scope.filePreviewContents.length);
 
                     }, function (error) {
                       //To hide README from UI

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
@@ -51,8 +51,10 @@ angular.module('hopsWorksApp')
                   MetadataHelperService, ProjectService, ExtendedMetadataService, ExtendedMetadataAPIService) {
             const PROJECT_ID = $routeParams.projectID;
             const DISTRIBUTION_ID = $routeParams.distributionID;
+            const parameters = $location.search();
             const self = this;
 
+            self.fileName = decodeURI(parameters.file);
             self.filePreviewLoaded = false;
             self.filePreviewShowing = false;
             self.template = {

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
@@ -294,6 +294,12 @@ angular.module('hopsWorksApp')
                 });
               }
 
+              // Clear fields if type of data is not tabular
+              if (fields.typeannotation.model.typeOfData != 'tabular') {
+                fields.typeannotation.model.fields = [];
+                graph[0]['aegis:hasField'] = [];
+              }
+
               // Send to API
               ExtendedMetadataAPIService.createOrUpdateDistributionMetadata(parameters.datasetID, PROJECT_ID, metadataObject)
                 .then(function(success) {

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
@@ -270,12 +270,12 @@ angular.module('hopsWorksApp')
               graph[0].description = fields.description.model;
               graph[0].title = fields.title.model;
               graph[0]['hops:fileId'] = DISTRIBUTION_ID;
-              graph[0]['dct:identifier'] = 'hdfs://' + path;
-              graph[0]['http://www.w3.org/ns/dcat#accessURL']['@id'] = 'hdfs://' + path;
+              graph[0]['dct:identifier'] = path;
+              graph[0]['http://www.w3.org/ns/dcat#accessURL']['@id'] = path;
 
               if (fields.format.model != '') graph[0]['dct:format'] = fields.format.model;
-              if (fields.language.model) graph[0]['language'] = 'http://publications.europa.eu/resource/authority/language/' + fields.language.model;
-              if (fields.license.model) graph[0].license = 'https://creativecommons.org/licenses/by/4.0/' + fields.license.model;
+              if (fields.language.model != '') graph[0]['language'] = 'http://publications.europa.eu/resource/authority/language/' + fields.language.model;
+              if (fields.license.model != '') graph[0].license = 'https://creativecommons.org/licenses/by/4.0/' + fields.license.model;
 
               if (fields.typeannotation.model.fields.length) {
                 var tabularFields = fields.typeannotation.model.fields;

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
@@ -270,8 +270,8 @@ angular.module('hopsWorksApp')
               graph[0].description = fields.description.model;
               graph[0].title = fields.title.model;
               graph[0]['hops:fileId'] = DISTRIBUTION_ID;
-              graph[0]['dct:identifier'] = path;
-              graph[0]['http://www.w3.org/ns/dcat#accessURL']['@id'] = path;
+              graph[0]['dct:identifier'] = 'hdfs://' + path;
+              graph[0]['http://www.w3.org/ns/dcat#accessURL']['@id'] = 'hdfs://' + path;
 
               if (fields.format.model != '') graph[0]['dct:format'] = fields.format.model;
               if (fields.language.model != '') graph[0]['language'] = 'http://publications.europa.eu/resource/authority/language/' + fields.language.model;

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
@@ -239,6 +239,7 @@ angular.module('hopsWorksApp')
             self.loadExtendedDistroMetadata = function () {
               var parameters = $location.search();
               var path = 'hdfs://' + decodeURI(parameters.path);
+              $scope.data.fields.accessUrl.model = path;
 
               ExtendedMetadataAPIService.getDistributionMetadata(path)
                 .then(function(data) {

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
@@ -221,6 +221,7 @@ angular.module('hopsWorksApp')
                   }
 
                   var new_field = {
+                    primary: entry[aegis_prexix + 'primary'] || false,
                     description: entry[aegis_prexix + 'description'] || '',
                     name: entry[aegis_prexix + 'name'] || '',
                     number: parseInt(entry[aegis_prexix + 'number'], 10) || '',
@@ -282,6 +283,7 @@ angular.module('hopsWorksApp')
                 tabularFields.forEach(function (field) {
                   var type = field.type ? "aegis:" + field.type : '';
                   graph[0]['aegis:hasField'].push({
+                    "aegis:primary": field.primary || false,
                     "aegis:description": field.description,
                     "aegis:name": field.name,
                     "aegis:number": field.number.toString(),

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
@@ -244,7 +244,6 @@ angular.module('hopsWorksApp')
 
               ExtendedMetadataAPIService.getDistributionMetadata(path)
                 .then(function(data) {
-                  console.log(data.data);
                   self.updateModelsFromData(data.data);
                 })
                 .catch(function(error) {

--- a/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/extendedMetadataFileCtrl.js
@@ -352,7 +352,6 @@ angular.module('hopsWorksApp')
                 
                 if (!self.filePreviewLoaded) {
                   $scope.filePreviewContents = 'Loading file preview...';
-                
                   dataSetService.filePreview(path, "head").then(
                     function (success) {
                       var truncation_length = 750;
@@ -365,9 +364,6 @@ angular.module('hopsWorksApp')
                       if ($scope.filePreviewContents.length > truncation_length) {
                         $scope.filePreviewContents = $scope.filePreviewContents.substring(0, truncation_length) + '\n\n[...]';
                       }
-
-                      console.log($scope.filePreviewContents.length);
-
                     }, function (error) {
                       //To hide README from UI
                       self.filePreviewLoaded = false;

--- a/aegis-web/yo/app/scripts/controllers/projectCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/projectCtrl.js
@@ -426,7 +426,8 @@ angular.module('hopsWorksApp')
             };
 
             self.goToDatasetExtendedMetadata = function (dataset) {
-              self.goToUrl('dataset/' + dataset.id + '/extended-metadata-dataset');
+              var url = 'dataset/' + dataset.id + '/extended-metadata-dataset';
+              self.goToUrl(url, {datasetName: dataset.name});
             };
 
             self.goToDistributionExtendedMetadata = function (file) {

--- a/aegis-web/yo/app/scripts/directives/extmdHeader.js
+++ b/aegis-web/yo/app/scripts/directives/extmdHeader.js
@@ -7,7 +7,9 @@
          transclude: true,
          templateUrl: 'templates/extended-metadata-header.html',
          link: function($scope, $elm, $attrs) {
+           $scope.name = $attrs.name;
            $scope.type = $attrs.type;
+           $scope.path = $attrs.name ? ': ' + $scope.name : '';
          },
      };
  });

--- a/aegis-web/yo/app/scripts/services/ExtendedMetadataService.js
+++ b/aegis-web/yo/app/scripts/services/ExtendedMetadataService.js
@@ -195,6 +195,7 @@ angular.module('hopsWorksApp')
       },
 
       FILE_FORMATS: [
+        { id: '', name: 'None' },
         { id: 'TAR', name: 'TAR' },
         { id: 'ZIP', name: 'ZIP' },
         { id: 'GIF', name: 'GIF' },
@@ -230,6 +231,7 @@ angular.module('hopsWorksApp')
       ],
 
       LANGUAGES: [
+        { id: '', name: 'None' },
         { id: 'BUL', name: 'Bulgarian' },
         { id: 'HRV', name: 'Croatian' },
         { id: 'CES', name: 'Czech' },
@@ -257,7 +259,8 @@ angular.module('hopsWorksApp')
       ],
 
       LICENCES: [
-        { id: 'CC0', name: 'CC0 - Creative Commons CC0 1.0 Universal', default: true },
+        { id: '', name: 'None', default: true  },
+        { id: 'CC0', name: 'CC0 - Creative Commons CC0 1.0 Universal' },
         { id: 'CC_BY', name: 'CC_BY - Creative Commons Attribution 4.0 International' },
         { id: 'CC_BYNC', name: 'CC_BYNC - Creative Commons Attribution–NonCommercial 4.0 International' },
         { id: 'CC_BYNCND', name: 'CC_BYNCND - Creative Commons Attribution–NonCommercial–NoDerivatives 4.0 International' },

--- a/aegis-web/yo/app/styles/style.css
+++ b/aegis-web/yo/app/styles/style.css
@@ -719,6 +719,10 @@ nav[data-toggle='toc'] {
     font-weight: 400;
 }
 
+tags-input .tags .tag-item {
+  background: #eaeaea;
+}
+
 /* nested links */
 .bs-docs-sidebar .nav .nav>li>a,
 .home-sidebar .nav .nav>li>a {

--- a/aegis-web/yo/app/templates/extended-metadata-header.html
+++ b/aegis-web/yo/app/templates/extended-metadata-header.html
@@ -1,6 +1,6 @@
  <div class="row content-utility-bar content-utility-bar-actions">
   <div class="col-md-8">
-      <h4 style="margin-top: 10px; margin-bottom: 5px">Project > Extended Metadata for {{type}} {{ $scope }}</h4>
+      <h4>Extended Metadata ({{type}}){{ path }}</h4>
   </div>
   <div class="col-md-4">
       <div class="pull-right">

--- a/aegis-web/yo/app/templates/extended-metadata-header.html
+++ b/aegis-web/yo/app/templates/extended-metadata-header.html
@@ -1,6 +1,6 @@
  <div class="row content-utility-bar content-utility-bar-actions">
   <div class="col-md-8">
-      <h4 style="margin-top: 10px; margin-bottom: 5px">Project > Extended Metadata for {{type}}</h4>
+      <h4 style="margin-top: 10px; margin-bottom: 5px">Project > Extended Metadata for {{type}} {{ $scope }}</h4>
   </div>
   <div class="col-md-4">
       <div class="pull-right">

--- a/aegis-web/yo/app/views/extended-metadata/dataset.html
+++ b/aegis-web/yo/app/views/extended-metadata/dataset.html
@@ -123,7 +123,7 @@
                                             </div>
 
                                             <div class="form-group bs-callout">
-                                              <label for="input-publisher">Publisher *</label>
+                                              <label for="input-publisher">Publisher</label>
 
                                               <div style="margin-bottom: 10px;margin-top: 10px">
                                                 <label for="publisher-type" id="input-publishertype" style="font-size: 14px">Publisher Type</label>

--- a/aegis-web/yo/app/views/extended-metadata/dataset.html
+++ b/aegis-web/yo/app/views/extended-metadata/dataset.html
@@ -47,7 +47,7 @@
                 <div>
                     <div class="container-fluid content-wrapper">
                         <div growl reference="3" class="pull-right"></div>
-                        <extmd-header type="Dataset"></extmd-header>
+                        <extmd-header type="Dataset" name="{{extendedMetadataCtrl.datasetName}}"></extmd-header>
                         <div class="row" style="margin-top: 15px">
                             <!-- Left menu -->
                             <div class="col-md-4 col-sm-4 col-lg-3">

--- a/aegis-web/yo/app/views/extended-metadata/dataset.html
+++ b/aegis-web/yo/app/views/extended-metadata/dataset.html
@@ -147,7 +147,8 @@
 
                                             <div class="form-group">
                                                 <label for="inputTheme3" id="input-theme">Theme/Category</label>
-                                                <select multiple id="inputTheme" class="form-control" size="13" ng-model="data.fields.theme.model">
+                                                <select id="inputTheme" class="form-control" ng-model="data.fields.theme.model">
+                                                    <option value="" selected>None</option>
                                                     <option value="AGRI">Agriculture, fisheries, forestry and food</option>
                                                     <option value="ECON">Economy and finance</option>
                                                     <option value="EDUC">Education, culture and sport</option>

--- a/aegis-web/yo/app/views/extended-metadata/distribution.html
+++ b/aegis-web/yo/app/views/extended-metadata/distribution.html
@@ -47,7 +47,7 @@
                 <div>
                     <div class="container-fluid content-wrapper">
                         <div growl reference="3" class="pull-right"></div>
-                        <extmd-header type="Distribution"></extmd-header>
+                        <extmd-header type="Distribution" name="{{extendedMetadataFileCtrl.fileName}}"></extmd-header>
                         <div class="row" style="margin-top: 15px">
                             <!-- Left menu -->
                             <div class="col-md-4 col-sm-4 col-lg-3">


### PR DESCRIPTION
- Save / Load publisher metadata (datasets)
- Select fields (license, language, file format, theme.. ) have default option / are resettable 
- Icons for Leaflet Map are correctly copied to dist-folder upon build
- removed color gradient for keywords input
- display dataset / distribution name in breadcrumb
- truncated file preview for longer files (distribution)
- show Access URL even if no metadata is present (distribution)
- fix loading of existing date into timepicker (datasets), allow start date only