### PR TITLE
Fix number of datasets in homepage

### DIFF
--- a/aegis-web/yo/app/index.html
+++ b/aegis-web/yo/app/index.html
@@ -215,6 +215,7 @@
     <script src="scripts/directives/extmdSidebarNav.js"></script>
     <script src="scripts/directives/filemgr/directives.js"></script>
     <script src="scripts/directives/sglclick.js"></script>
+    <script src="scripts/directives/lblProjectDatasets.js"></script>
 
     <script src="scripts/controllers/dataSetCreatorCtrl.js"></script>
     <script src="scripts/controllers/datasetsCtrl.js"></script>
@@ -366,6 +367,7 @@
     <script src="scripts/services/FeaturestoreService.js"></script>
     <script src="scripts/services/ExtendedMetadataService.js"></script>
     <script src="scripts/services/ExtendedMetadataAPIService.js"></script>
+    <script src="scripts/services/AegisProjectInfoService.js"></script>
     <!-- wallet -->
     <script src="scripts/services/WalletService.js"></script>
     <script src="scripts/services/ItemAccessService.js"></script>

--- a/aegis-web/yo/app/scripts/directives/lblProjectDatasets.js
+++ b/aegis-web/yo/app/scripts/directives/lblProjectDatasets.js
@@ -1,0 +1,44 @@
+'use strict';
+
+angular.module('hopsWorksApp').directive('lblProjectDatasets', [function () {
+    return {
+        restrict: 'E',
+        template: '{{label}}',
+        scope: {
+            projectId: '@',
+            files: '@',
+        },
+        controller: ['$scope', '$http', 'AegisProjectInfoService', function ($scope, $http, AegisProjectInfoService) {
+            $scope.label = "";
+            var projectId = NaN;
+            var files = NaN;
+            if ($scope.projectId !== undefined) {
+                projectId = parseInt($scope.projectId);
+            }
+            if ($scope.files !== undefined) {
+                files = parseInt($scope.files);
+            }
+            if (!isNaN(projectId)) {
+                AegisProjectInfoService.getDatasets(projectId).then(function (data) {
+                    if (data && data.datasets) {
+                        $scope.label = data.datasets + " dataset";
+                        if (data.datasets > 1) {
+                            $scope.label += "s";
+                        }
+                    }
+                });
+                return;
+            }
+            if (!isNaN(files)) {
+                AegisProjectInfoService.getFiles(files).then(function (data) {
+                    if (data && data.files) {
+                        $scope.label = data.files + " file";
+                        if (data.files > 1) {
+                            $scope.label += "s";
+                        }
+                    }
+                });
+            }
+        }]
+    };
+}]);

--- a/aegis-web/yo/app/scripts/directives/lblProjectDatasets.js
+++ b/aegis-web/yo/app/scripts/directives/lblProjectDatasets.js
@@ -19,7 +19,7 @@ angular.module('hopsWorksApp').directive('lblProjectDatasets', [function () {
                 files = parseInt($scope.files);
             }
             if (!isNaN(projectId)) {
-                AegisProjectInfoService.getDatasets(projectId).then(function (data) {
+                AegisProjectInfoService.getDatasetsCount(projectId).then(function (data) {
                     if (data && data.datasets) {
                         $scope.label = data.datasets + " dataset";
                         if (data.datasets > 1) {

--- a/aegis-web/yo/app/scripts/services/AegisProjectInfoService.js
+++ b/aegis-web/yo/app/scripts/services/AegisProjectInfoService.js
@@ -1,0 +1,55 @@
+'use strict';
+
+angular.module('hopsWorksApp')
+    .factory('AegisProjectInfoService', ['$http', '$q', '$cacheFactory', '$timeout', function ($http, $q, $cacheFactory, $timeout) {
+        var myCache = $cacheFactory('AegisProjectInfoService');
+        return {
+            getDatasets: function (projectId) {
+                return $q(function (resolve, reject) {
+                    var cacheKey = projectId + 'datasets';
+                    var cached = myCache.get(cacheKey);
+                    if (!cached) {
+                        $http.get(`/api/project/${projectId}/dataset/getContent`).then(function (success) {
+                            if (success.data && success.data.length) {
+                                var value = success.data.length;
+                                $timeout(function () {
+                                    myCache.put(cacheKey, value);
+                                }, 0);
+                                resolve({
+                                    datasets: value
+                                });
+                            }
+                        }, reject);
+                    } else {
+                        resolve({
+                            datasets: cached
+                        });
+                    }
+                });
+            },
+            getFiles: function (projectId) {
+                return $q(function (resolve, reject) {
+                    var cacheKey = projectId + 'files';
+                    var cached = myCache.get(cacheKey);
+                    if (!cached) {
+                        $http.get(`/api/project/${projectId}/quotas`).then(function (success) {
+                            if (success.data && success.data.hdfsNsCount && parseInt(success.data.hdfsNsCount)) {
+                                var value = parseInt(success.data.hdfsNsCount);
+                                $timeout(function () {
+                                    myCache.put(cacheKey, value);
+                                }, 0);
+                                resolve({
+                                    files: value
+                                });
+                            }
+                        }, reject);
+                    } else {
+                        resolve({
+                            files: cached
+                        });
+                    }
+                });
+            }
+        };
+    }]);
+

--- a/aegis-web/yo/app/scripts/services/AegisProjectInfoService.js
+++ b/aegis-web/yo/app/scripts/services/AegisProjectInfoService.js
@@ -4,20 +4,22 @@ angular.module('hopsWorksApp')
     .factory('AegisProjectInfoService', ['$http', '$q', '$cacheFactory', '$timeout', function ($http, $q, $cacheFactory, $timeout) {
         var myCache = $cacheFactory('AegisProjectInfoService');
         return {
-            getDatasets: function (projectId) {
+            getDatasetsCount: function (projectId) {
                 return $q(function (resolve, reject) {
-                    var cacheKey = projectId + 'datasets';
+                    var cacheKey = projectId + 'datasetscount';
                     var cached = myCache.get(cacheKey);
                     if (!cached) {
-                        $http.get(`/api/project/${projectId}/dataset/getContent`).then(function (success) {
-                            if (success.data && success.data.length) {
-                                var value = success.data.length;
+                        $http.get(`/api/project/${projectId}/dataset/getContent?count=true`).then(function (success) {
+                            if (success.data && success.data.datasetCount) {
+                                var value = success.data.datasetCount;
                                 $timeout(function () {
                                     myCache.put(cacheKey, value);
                                 }, 0);
                                 resolve({
                                     datasets: value
                                 });
+                            } else {
+                                reject("Server error: not expected response");
                             }
                         }, reject);
                     } else {
@@ -41,6 +43,8 @@ angular.module('hopsWorksApp')
                                 resolve({
                                     files: value
                                 });
+                            } else {
+                                reject("Server error: not expected response");
                             }
                         }, reject);
                     } else {

--- a/aegis-web/yo/app/views/home.html
+++ b/aegis-web/yo/app/views/home.html
@@ -65,7 +65,7 @@
           title="{{project.project.name.length > 28 ? project.project.name:''}}"
         >
           <h4 class="home-project-container-title">{{ project.project.name | limitTo: 18 }}{{project.project.name.length > 18 ? '...' : ''}}</h4>
-          <div class="home-project-container-title">5 datasets</div>
+          <div class="home-project-container-title"><lbl-project-datasets project-id="{{project.project.id}}"></lbl-project-datasets></div>
         </a>
       </div>
 


### PR DESCRIPTION
fixes https://github.com/aegisbigdata/documentation/issues/208
There's a delay fetching the dataset number for each project but the result is cached so it should be instant if the user visits the same page without reloading the browser (eg. use pagination or open a project and go back to homepage).

There are two options using the directive.

- with **project-id** it will display the number of datasets pluralized (1 dataset, 2 datasets)
`<lbl-project-datasets project-id="{{project.project.id}}"></lbl-project-datasets>`
- with **files** it will display the number of files pluralized (1 file, 2 files)
`<lbl-project-datasets files="{{project.project.id}}"></lbl-project-datasets>`

files is faster since the api is faster.

![image](https://user-images.githubusercontent.com/1640100/61099022-46e97a00-a461-11e9-8927-30431d749d90.png)
