### PR TITLE
Make the utilization bar smaller when server is idle

### DIFF
--- a/aegis-web/yo/app/scripts/controllers/clusterUtilisationCtrl.js
+++ b/aegis-web/yo/app/scripts/controllers/clusterUtilisationCtrl.js
@@ -92,7 +92,7 @@ angular.module('hopsWorksApp')
                         var vCoreUtilisation = (self.allocatedVCores / totalVCores) * 100;
                         var MBUtilisation = (self.allocatedMB / totalMB) * 100;
                         self.utilisation = Math.round(Math.max(vCoreUtilisation, MBUtilisation))
-                        self.utilisationBar = Math.max(self.utilisation, 10);
+                        self.utilisationBar = Math.max(self.utilisation, 1);
                         
                         if (self.utilisation <= 50) {
                           self.progressBarClass = 'progress-bar-success';


### PR DESCRIPTION
Closes https://github.com/aegisbigdata/documentation/issues/174
![image](https://user-images.githubusercontent.com/1640100/61099964-88c7ef80-a464-11e9-9e49-b29285a09c2e.png)
